### PR TITLE
Use generated specs

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -11,3 +11,4 @@ vscode:
     - adacore.ada
     - llvm-vs-code-extensions.vscode-clangd
     - mhutchie.git-graph
+    - ibm.output-colorizer

--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,9 @@ current_dir := $(patsubst %/,%,$(dir $(mkfile_path)))
 export ADA = arm-zephyr-eabi-g++
 export ADAFLAGS = --RTS=$(current_dir)/modules/gnat -I$(current_dir)/build -gnat12
 
+.PHONY : all
+all : zephyr-export init-repo build
+
 # See https://docs.zephyrproject.org/latest/guides/zephyr_cmake_package.html
 # Only for ver 2.2.99+
 .PHONY: zephyr-export

--- a/Makefile
+++ b/Makefile
@@ -10,13 +10,13 @@ endif
 
 PLATFORM_SPECIFIC_LOCS_ARG=-DKCONFIG_ROOT=KConfig -DOUT_OF_TREE_BOARD=OFF -DOUT_OF_TREE_SOC=OFF -DOUT_OF_TREE_DTS=OFF
 CONF_FILE ?= prj_uart_shell.conf
-# EXTRA_CFLAGS := -fdump-ada-spec
+EXTRA_CFLAGS := -fdump-ada-spec
 
 mkfile_path := $(abspath $(lastword $(MAKEFILE_LIST)))
 current_dir := $(patsubst %/,%,$(dir $(mkfile_path)))
 
-export ADA = arm-zephyr-eabi-gcc
-export ADAFLAGS = --RTS=$(current_dir)/modules/gnat -I/workspaces/ada-project-example/build -gnat12
+export ADA = arm-zephyr-eabi-g++
+export ADAFLAGS = --RTS=$(current_dir)/modules/gnat -I$(current_dir)/build -gnat12
 
 # See https://docs.zephyrproject.org/latest/guides/zephyr_cmake_package.html
 # Only for ver 2.2.99+

--- a/app/CMakeLists.txt
+++ b/app/CMakeLists.txt
@@ -17,4 +17,5 @@ target_sources(
     PRIVATE
         src/main.cpp
         src/hello.adb
+        src/put_time.adb
 )

--- a/app/src/hello.adb
+++ b/app/src/hello.adb
@@ -1,6 +1,16 @@
 with Ada.Text_IO;
+with Put_Time;
+
+with stdint_h; use stdint_h; 
+with generated_syscalls_kernel_h; use generated_syscalls_kernel_h;
 
 procedure Hello is
+   ret: int32_t;
 begin
-   Ada.Text_IO.Put_Line("Hello, world! It's Ada!");
+   loop
+      Put_Time;
+      Ada.Text_IO.Put_Line("Hello, world! It's Ada!");
+
+      ret := z_impl_k_usleep(200000);
+   end loop;
 end Hello;

--- a/app/src/main.cpp
+++ b/app/src/main.cpp
@@ -9,11 +9,6 @@ extern "C" {
 
 void main()
 {
-    while (true) {
-        LOG_INF("Hello World!");
-        ada_hello();
-
-        k_cpu_idle();
-        k_sleep(K_MSEC(100));
-    }
+    LOG_INF("Start Ada execution!");
+    ada_hello();
 }

--- a/app/src/put_time.adb
+++ b/app/src/put_time.adb
@@ -1,0 +1,12 @@
+with Ada.Text_IO;
+with Interfaces.C; use Interfaces.C;
+
+with arch_arm_aarch32_misc_h; use arch_arm_aarch32_misc_h;
+
+procedure Put_Time is
+   Current_Time : unsigned;
+begin
+   Current_Time := z_timer_cycle_get_32;
+
+   Ada.Text_IO.Put("[" & unsigned'Image(Current_Time) & "] ");
+end Put_Time;

--- a/app/src/put_time.ads
+++ b/app/src/put_time.ads
@@ -1,0 +1,1 @@
+procedure Put_Time;

--- a/app/west.yml
+++ b/app/west.yml
@@ -33,7 +33,7 @@ manifest:
 
     - name: zephyr-ada-gnat-rts
       remote: zephyr-ada
-      revision: b2593b5e84a46067784c3938091e72c7897b2556 
+      revision: 6c2abaeb413ef9603a2bedf4e0c047d4c8dd5b7c 
       path: modules/gnat
 
     - name: zephyr

--- a/cmake-variants.yaml
+++ b/cmake-variants.yaml
@@ -15,7 +15,7 @@ app:
         KCONFIG_ROOT: KConfig
         # CMAKE_VERBOSE_MAKEFILE: ON
         # ZEPHYR_MODULES: <path-to-module1>[;<path-to-module2>[...]]
-        # EXTRA_CFLAGS: -fdump-ada-spec # -H
+        EXTRA_CFLAGS: -fdump-ada-spec # -H
       env:
         ADA: arm-zephyr-eabi-gcc
         ADAFLAGS: --RTS=${workspaceFolder}/modules/gnat -I${workspaceFolder}/build -gnat12
@@ -34,7 +34,7 @@ app:
         KCONFIG_ROOT: KConfig
         # CMAKE_VERBOSE_MAKEFILE: ON
         # ZEPHYR_MODULES: <path-to-module1>[;<path-to-module2>[...]]
-        # EXTRA_CFLAGS: -fdump-ada-spec # -H
+        EXTRA_CFLAGS: -fdump-ada-spec # -H
       env:
         ADA: arm-zephyr-eabi-gcc
         ADAFLAGS: --RTS=${workspaceFolder}/modules/gnat -I${workspaceFolder}/build -gnat12


### PR DESCRIPTION
GCC compiler can generate Ada specs from C files. Enable it for the Zephyr kernel and use it in the example.